### PR TITLE
Actualización P1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,9 +11,15 @@ class VagrantPlugins::ProviderVirtualBox::Action::Network
 end
 
 Vagrant.configure("2") do |config|
-    config.vm.box = 
+    config.vm.box = XXX
     config.vm.hostname = "XXX-aisi2223-docker"
     config.vm.network "XXX", guest: XXX, host: XXX
+
+    # Configure hostmanager and vbguest plugins
+    config.hostmanager.enabled = true
+    config.hostmanager.manage_host = true
+    config.hostmanager.manage_guest = true
+    config.vbguest.auto_update = false
 
     config.vm.provider "virtualbox" do |vb|
 	vb.name = "AISI-P1-#{config.vm.hostname}"

--- a/provisioning/Vagrantfile.template
+++ b/provisioning/Vagrantfile.template
@@ -1,0 +1,20 @@
+Vagrant.configure("2") do |config|
+  config.vm.define "source", autostart: false do |source|
+	source.vm.box = "{{.SourceBox}}"
+	config.ssh.insert_key = {{.InsertKey}}
+	source.vbguest.auto_update = false
+	source.vm.provider "virtualbox" do |vb|
+		vb.cpus = 1
+	end
+  end
+  config.vm.define "output" do |output|
+	output.vm.box = "{{.BoxName}}"
+	output.vm.box_url = "file://package.box"
+	config.ssh.insert_key = {{.InsertKey}}
+  end
+  {{ if ne .SyncedFolder "" -}}
+  		config.vm.synced_folder "{{.SyncedFolder}}", "/vagrant"
+  {{- else -}}
+  		config.vm.synced_folder ".", "/vagrant", disabled: true
+  {{- end}}
+end

--- a/provisioning/install-docker-ubuntu.sh
+++ b/provisioning/install-docker-ubuntu.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-echo -e "deb https://ftp.udc.es/ubuntu focal main restricted \n
-	deb https://ftp.udc.es/ubuntu focal-updates main restricted \n
-	deb https://ftp.udc.es/ubuntu focal-security main restricted \n
-	deb https://ftp.udc.es/ubuntu focal universe \n
-	deb https://ftp.udc.es/ubuntu focal-updates universe \n" | sudo tee /etc/apt/sources.list > /tmp/repo-log
+echo -e "deb https://ftp.udc.es/ubuntu focal main restricted
+deb https://ftp.udc.es/ubuntu focal-updates main restricted
+deb https://ftp.udc.es/ubuntu focal-security main restricted
+deb https://ftp.udc.es/ubuntu focal universe
+deb https://ftp.udc.es/ubuntu focal-updates universe" | sudo tee /etc/apt/sources.list > /tmp/repo-log
 
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg lsb-release

--- a/provisioning/install-docker-ubuntu.sh
+++ b/provisioning/install-docker-ubuntu.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+echo -e "deb https://ftp.udc.es/ubuntu focal main restricted \n
+	deb https://ftp.udc.es/ubuntu focal-updates main restricted \n
+	deb https://ftp.udc.es/ubuntu focal-security main restricted \n
+	deb https://ftp.udc.es/ubuntu focal universe \n
+	deb https://ftp.udc.es/ubuntu focal-updates universe \n" | sudo tee /etc/apt/sources.list > /tmp/repo-log
+
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg lsb-release
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg

--- a/template.pkr.hcl
+++ b/template.pkr.hcl
@@ -5,6 +5,7 @@ source "vagrant" "aisi" {
   provider     = "XXX"
   add_force    = true
   skip_add     = true
+  template     = "provisioning/Vagrantfile.template"
 }
 
 build {


### PR DESCRIPTION
Se actualizó el repositorio para modificar el script de instalación de Docker donde ahora se configuran los mismos repositorios de Ubuntu que en la práctica previa por el mismo motivo. También se modificó la plantilla HCL para indicar el uso de un Vagrantfile específico (provisioning/Vagrantfile.template) durante la creación del box, donde se configura que no se actualicen las VBox Guest Additions y acelerar así la creación de la imagen.